### PR TITLE
fix(package): The repository has moved URL, also a broken URL

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!-- Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ of the ["Fetch a Profile"][FetchProfile doc] documentation is at
 
 
 [Launch API doc]: https://developer.adobelaunch.com/api/ 'Adobe Experience Platform Launch API'
-[Launch API doc repo]: https://github.com/Adobe-Marketing-Cloud/reactor-developer-docs 'Launch API documentation repository'
+[Launch API doc repo]: https://github.com/adobe/reactor-developer-docs 'Launch API documentation repository'
 [FetchProfile doc]: https://developer.adobelaunch.com/api/reference/1.0/profiles/fetch/ 'Fetch a Profile'
-[FetchProfile impl]: https://github.com/Adobe-Marketing-Cloud/reactor-sdk-javascript/blob/0d10436c31ab84772882ead2e4da6cc9d41fc7bc/src/profiles.js#L13
-[FetchProfile doc src]: https://github.com/Adobe-Marketing-Cloud/reactor-developer-docs/blob/master/api/reference/1.0/profiles/fetch.md 'Fetch a Profile'
+[FetchProfile impl]: https://github.com/adobe/reactor-sdk-javascript/blob/master/src/profiles.js#L13
+[FetchProfile doc src]: https://github.com/adobe/reactor-developer-docs/blob/master/api/reference/1.0/profiles/fetch.md 'Fetch a Profile'
 [ListCompanies doc]: https://developer.adobelaunch.com/api/reference/1.0/companies/list/ 'List Companies'
 
 Every SDK function [has an integration test](test/integration)
@@ -152,14 +152,14 @@ isn't quite true yet.  We're almost there, but a few remain to be implemented.]
 For a complete and self-contained example program, see
 [examples.test.js](./test/integration/examples.test.js), which is included in
 the integration tests. It's a JavaScript implementation of the [Reactor
-Postman]( https://github.com/Adobe-Marketing-Cloud/reactor-postman) query set.
+Postman]( https://github.com/adobe/reactor-postman) query set.
 
 ## Developer Setup
 
 If you want to contribute to development of this library,
 
 ```bash
-$ git clone git@github.com:Adobe-Marketing-Cloud/reactor-sdk-javascript.git
+$ git clone git@github.com:adobe/reactor-sdk-javascript.git
 $ cd reactor-sdk-javascript
 $ npm clean-install           # install dependencies and build Reactor SDK library
 ```
@@ -251,5 +251,5 @@ $ script/delete-test-properties
 
 ## Contributing
 
-Contributions are welcomed! Read the [Contributing Guide](https://github.com/Adobe-Marketing-Cloud/reactor-sdk-javascript/blob/master/CONTRIBUTING.md)
+Contributions are welcomed! Read the [Contributing Guide](https://github.com/adobe/reactor-sdk-javascript/blob/master/CONTRIBUTING.md)
 for more information.

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Adobe-Marketing-Cloud/reactor-sdk-javascript/issues"
+    "url": "https://github.com/adobe/reactor-sdk-javascript/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https@github.com:Adobe-Marketing-Cloud/reactor-sdk-javascript.git"
+    "url": "git+https@github.com:adobe/reactor-sdk-javascript.git"
   },
   "keywords": [
     "Adobe",

--- a/test/integration/all-tests.js
+++ b/test/integration/all-tests.js
@@ -92,6 +92,6 @@ import './properties.test.js';
 import './rule-components.test.js';
 import './rules.test.js';
 
-// [Reactor Postman](https://github.com/Adobe-Marketing-Cloud/reactor-postman),
+// [Reactor Postman](https://github.com/adobe/reactor-postman),
 // re-imagined via the JavaScript SDK.
 import './examples.test.js';

--- a/test/integration/examples.test.js
+++ b/test/integration/examples.test.js
@@ -19,7 +19,7 @@ describe('Reactor SDK Example', function() {
   afterAll(() => console.groupEnd('Awesome Example'));
 
   // CREDIT: The actions of this script are inspired by
-  // [Reactor Postman](https://github.com/Adobe-Marketing-Cloud/reactor-postman).
+  // [Reactor Postman](https://github.com/adobe/reactor-postman).
   runStep('create a Property', makeNewAwesomePR);
   runStep('find ExtensionPackages', findThreeEP);
   runStep('find core Extension', findCoreEX);


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The package.json file is currently pointed to `Adobe-Marketing-Cloud`, the repository now currently lives at `adobe`. Also a broken URL: https://github.com/Adobe-Marketing-Cloud/reactor-sdk-javascript/blob/0d10436c31ab84772882ead2e4da6cc9d41fc7bc/src/profiles.js#L13 in the README.md.

<!--- Describe your changes in detail -->
## Types of changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [✓] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [✓] I have read the **CONTRIBUTING** document.
