### PR TITLE
remove method for nonexistent endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1687,26 +1687,6 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
-    "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
-      "dev": true,
-      "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      }
-    },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",

--- a/src/rule-components.js
+++ b/src/rule-components.js
@@ -44,11 +44,6 @@ export function listRulesForRuleComponent(ruleComponentId) {
   return this.get(`/rule_components/${ruleComponentId}/rules`);
 }
 
-// List Rule relationships for a RuleComponent
-export function listRuleRelationshipsForRuleComponent(ruleComponentId) {
-  return this.get(`/rule_components/${ruleComponentId}/relationships/rule`);
-}
-
 // Get the origin
 // https://developer.adobelaunch.com/api/rule_components/origin/
 export function getOriginForRuleComponent(ruleComponentId) {

--- a/test/integration/rule-components.test.js
+++ b/test/integration/rule-components.test.js
@@ -86,18 +86,6 @@ helpers.describe('RuleComponent API', function() {
     expect(response.data[0].type).toBe('rules');
   });
 
-  // List Rules for a RuleComponent
-  // https://developer.adobelaunch.com/api/reference/1.0/rule_components/relationships/rules/list_related/
-  // NOTE that (for now) in this actually returns a single rule, NOT a list.
-  helpers.it('lists Rule relationships for a RuleComponent', async function() {
-    const rcLevan = await makeTestRC('Levan', 11);
-    const response = await reactor.listRuleRelationshipsForRuleComponent(
-      rcLevan.id
-    );
-    expect(response.data.id).toBe(theRule.id);
-    expect(response.data.type).toBe('rules');
-  });
-
   // Get a RuleComponent's origin
   // https://developer.adobelaunch.com/api/rule_components/origin/
   helpers.it("gets a RuleComponent's origin", async function() {

--- a/test/unit/rule-component.test.js
+++ b/test/unit/rule-component.test.js
@@ -83,16 +83,6 @@ describe('RuleComponent:', function() {
     });
   });
 
-  describe('listRuleRelationshipsForRuleComponent', function() {
-    it('runs an http GET', async function() {
-      context.expectRequest(
-        'get',
-        `/rule_components/${ruleComponentId}/relationships/rule`
-      );
-      await reactor.listRuleRelationshipsForRuleComponent(ruleComponentId);
-    });
-  });
-
   describe('deleteRuleComponent', function() {
     it('runs an http DELETE', async function() {
       context.expectRequest('delete', `/rule_components/${ruleComponentId}`);


### PR DESCRIPTION
The method `listRuleRelationshipsForRuleComponent(ruleComponentId)`
does not exist in Reactor API 1.0.

It used to list Rule relationships for a RuleComponent, but that
endpoint (`GET /rule_components/${ruleComponentId}/relationships/rule`)
did not make it into the 1.0 release.

So remove it from the library.
