### PR TITLE
Added support for query params on getting rule revisions

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -57,8 +57,8 @@ export function listRulesForProperty(propertyId, queryParams) {
 
 // List revisions
 // https://developer.adobelaunch.com/api/rules/revisions/
-export function listRevisionsForRule(ruleId) {
-  return this.get(`/rules/${ruleId}/revisions`);
+export function listRevisionsForRule(ruleId, queryParams) {
+  return this.get(`/rules/${ruleId}/revisions`, queryParams);
 }
 
 // Revise a Rule

--- a/test/integration/rules.test.js
+++ b/test/integration/rules.test.js
@@ -231,6 +231,17 @@ helpers.describe('Rule API', function() {
     expect(ids).toContain(snowy2.id);
   });
 
+  // Test filter on listRevisionsForRule
+  helpers.it('gets a filtered rule revision', async function() {
+    await initializeSnowyRiver(2);
+    const revisionsList = await reactor.listRevisionsForRule(snowy.id, {
+      'filter[revision_number]': 'EQ 1'
+    });
+    const revisionIds = revisionsList.data.map(revision => revision.id);
+    expect(revisionIds).toContain(snowy1.id);
+    expect(revisionIds).not.toContain(snowy.id);
+  });
+
   // Revise a Rule
   // https://developer.adobelaunch.com/api/rules/revise/
   helpers.it('revises a Rule', async function() {


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added support for query parameters to filter rule revisions. It's fully backwards compatible and should not affect any current usages without query parameters. Closes #64 

## Related Issue

#64 

## Motivation and Context

The Reactor API supports filtering revisions, but that functionality has not been built into the JavaScript SDK yet. This adds support for rules, but support for filtering other resource revisions needs to be added as well. Ticket for that [here:](https://jira.corp.adobe.com/browse/PDCL-9582)

## How Has This Been Tested?

I wrote an integration test to filter on rule revisions. I also manually tested using the below code to test against multiple rules on a property.

``` javascript
let rulesForProperty = await reactor.listRulesForProperty(propertyId);
for (let rule of rulesForProperty.data) {
  await reactor.listRevisionsForRule(
    rule.id,
    {'filter[published]': 'EQ true'}
  ).then(revisionList => {
    revisionList.data.map(ruleRevision => {
      console.log(`${ruleRevision.attributes.name}: `, ruleRevision);
    });
  });
};
```

I swapped out what was being filtered to test multiple attributes.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.