### PR TITLE
Cluster gateway changes enabled api rate limiting.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,14 +108,40 @@ export default class Reactor {
     return responseData;
   }
 
-  async request(method, url, requestData = null) {
+  async request(method, url, requestData = null, retryCount = 0) {
+    const maxRetries = 3;
     const requestBodyJson = requestData && JSON.stringify(requestData);
     const requestInfo = {
       method: method,
       headers: this.headers,
       body: requestBodyJson
     };
-    return await this.requestAndLog(url, requestInfo, requestData);
+
+    try {
+      return await this.requestAndLog(url, requestInfo, requestData);
+    } catch (error) {
+      // Retry on 429 (Too Many Requests) with respect to retry-after header
+      if (
+        error instanceof FetchError &&
+        error.status === 429 &&
+        retryCount < maxRetries
+      ) {
+        // Get retry-after header (in seconds)
+        const retryAfter = error.traceData.response.headers.get('retry-after');
+        const retryAfterSeconds = retryAfter ? parseInt(retryAfter, 10) : 5;
+        // Add 1 second buffer as requested
+        const waitSeconds = retryAfterSeconds + 1;
+        const waitMs = waitSeconds * 1000;
+
+        console.info(
+          `[Blacksmith API] --------------- The API has asked us to wait ${waitSeconds} seconds before making calls again. ---------------`
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+        return await this.request(method, url, requestData, retryCount + 1);
+      }
+      throw error;
+    }
   }
 
   async sendMultipartFile(method, url, fileObject) {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -110,43 +110,32 @@ const helpers = {
 
   async createTestProperty(baseName) {
     const ctx = `while creating "${baseName}" test Property:`;
-    try {
-      const response = await reactor.createProperty(helpers.companyId, {
-        attributes: {
-          domains: ['testing.reactor.adobe.com'],
-          name: makeNameForTestObject('Property', baseName),
-          platform: 'web'
-        },
-        type: 'properties'
-      });
-      expectWithContext(response.data.id, ctx).toMatch(helpers.idPR);
-      return response.data;
-    } catch (error) {
-      helpers.specName = ctx;
-      helpers.reportError(error);
-      return false;
-    }
+    const response = await reactor.createProperty(helpers.companyId, {
+      attributes: {
+        domains: ['testing.reactor.adobe.com'],
+        name: makeNameForTestObject('Property', baseName),
+        platform: 'web'
+      },
+      type: 'properties'
+    });
+    expectWithContext(response.data.id, ctx).toMatch(helpers.idPR);
+    return response.data;
   },
 
   async createTestLibrary(propertyId, baseName) {
     const ctx = `while creating "${baseName}" test Library:`;
-    try {
-      if (!propertyId)
-        propertyId = await helpers.createTestProperty(baseName).id;
-      if (!propertyId) return false;
-      const response = await reactor.createLibrary(propertyId, {
-        attributes: {
-          name: makeNameForTestObject('Library', baseName)
-        },
-        type: 'libraries'
-      });
-      expectWithContext(response.data.id, ctx).toMatch(helpers.idLB);
-      return response.data;
-    } catch (error) {
-      helpers.specName = ctx;
-      helpers.reportError(error);
-      return false;
+    if (!propertyId) {
+      const property = await helpers.createTestProperty(baseName);
+      propertyId = property.id;
     }
+    const response = await reactor.createLibrary(propertyId, {
+      attributes: {
+        name: makeNameForTestObject('Library', baseName)
+      },
+      type: 'libraries'
+    });
+    expectWithContext(response.data.id, ctx).toMatch(helpers.idLB);
+    return response.data;
   },
 
   async addCoreToLibrary(property, library) {
@@ -174,64 +163,52 @@ const helpers = {
 
   async createTestSftpHost(propertyId, baseName) {
     const ctx = `while creating "${baseName}" test Host:`;
-    try {
-      /*eslint-disable camelcase*/
-      const response = await reactor.createHost(propertyId, {
-        attributes: {
-          name: makeNameForTestObject('Host', baseName),
-          type_of: 'sftp',
-          username: 'John Doe',
-          encrypted_private_key:
-            '-----BEGIN PGP MESSAGE-----\n\n' +
-            'this+is+a+bogus+private+key+nnnnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' +
-            'rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n' +
-            'KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh\n' +
-            'OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO++++++++++++++++++++++++++++++++\n' +
-            'SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\n' +
-            'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB77777777777777777777777777777777\n' +
-            'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG\n' +
-            'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW00000000000000000000000000000000\n' +
-            'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD\n' +
-            'jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE\n' +
-            '8888888888888888888888888888888811111111111111111111111111111111\n' +
-            'TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTssssssssssssssssssssssssssssssss\n' +
-            'LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL//////////==\n=oRpa\n' +
-            '-----END PGP MESSAGE-----\n',
-          server: 'example.com',
-          path: 'assets',
-          port: 22
-        },
-        type: 'hosts'
-      });
-      /*eslint-enable camelcase*/
-      expectWithContext(response.data.id, ctx).toMatch(helpers.idHT);
-      return response.data;
-    } catch (error) {
-      helpers.specName = ctx;
-      helpers.reportError(error);
-      return false;
-    }
+    /*eslint-disable camelcase*/
+    const response = await reactor.createHost(propertyId, {
+      attributes: {
+        name: makeNameForTestObject('Host', baseName),
+        type_of: 'sftp',
+        username: 'John Doe',
+        encrypted_private_key:
+          '-----BEGIN PGP MESSAGE-----\n\n' +
+          'this+is+a+bogus+private+key+nnnnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' +
+          'rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n' +
+          'KKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh\n' +
+          'OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO++++++++++++++++++++++++++++++++\n' +
+          'SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\n' +
+          'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB77777777777777777777777777777777\n' +
+          'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG\n' +
+          'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW00000000000000000000000000000000\n' +
+          'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD\n' +
+          'jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE\n' +
+          '8888888888888888888888888888888811111111111111111111111111111111\n' +
+          'TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTssssssssssssssssssssssssssssssss\n' +
+          'LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL//////////==\n=oRpa\n' +
+          '-----END PGP MESSAGE-----\n',
+        server: 'example.com',
+        path: 'assets',
+        port: 22
+      },
+      type: 'hosts'
+    });
+    /*eslint-enable camelcase*/
+    expectWithContext(response.data.id, ctx).toMatch(helpers.idHT);
+    return response.data;
   },
 
   async createTestAkamaiHost(propertyId, baseName) {
     const ctx = `while creating "${baseName}" test Host:`;
-    try {
-      /*eslint-disable camelcase*/
-      const response = await reactor.createHost(propertyId, {
-        attributes: {
-          name: makeNameForTestObject('Host', baseName),
-          type_of: 'akamai'
-        },
-        type: 'hosts'
-      });
-      /*eslint-enable camelcase*/
-      expectWithContext(response.data.id, ctx).toMatch(helpers.idHT);
-      return response.data;
-    } catch (error) {
-      helpers.specName = ctx;
-      helpers.reportError(error);
-      return false;
-    }
+    /*eslint-disable camelcase*/
+    const response = await reactor.createHost(propertyId, {
+      attributes: {
+        name: makeNameForTestObject('Host', baseName),
+        type_of: 'akamai'
+      },
+      type: 'hosts'
+    });
+    /*eslint-enable camelcase*/
+    expectWithContext(response.data.id, ctx).toMatch(helpers.idHT);
+    return response.data;
   },
 
   // Create an Environment using the identified Host.
@@ -251,37 +228,31 @@ const helpers = {
   async createTestEnvironment(propertyId, baseName, hostId = null) {
     let ctx = `while creating "${baseName}" test Environment`;
     ctx += ` on ${propertyId} ${hostId}:`;
-    try {
-      const kind = determineHostKind(hostId);
-      if (kind === 'sftp') {
-        const host = await helpers.createTestSftpHost(propertyId, baseName);
-        hostId = host.id;
-      } else if (kind === 'akamai') {
-        const host = await helpers.createTestAkamaiHost(propertyId, baseName);
-        hostId = host.id;
-      }
-      const attributes = {
-        name: makeNameForTestObject('Environment', baseName),
-        stage: determineEnvironmentStage(baseName)
-      };
-      if (kind !== 'akamai') {
-        attributes.path = 'https://example.com/';
-      }
-      const response = await reactor.createEnvironment(propertyId, {
-        type: 'environments',
-        attributes: attributes,
-        relationships: {
-          host: { data: { type: 'hosts', id: hostId } }
-        }
-      });
-      expectWithContext(response.data.id, ctx).toMatch(helpers.idEN);
-      response.data.associatedHostId = hostId;
-      return response.data;
-    } catch (error) {
-      helpers.specName = ctx;
-      helpers.reportError(error);
-      return false;
+    const kind = determineHostKind(hostId);
+    if (kind === 'sftp') {
+      const host = await helpers.createTestSftpHost(propertyId, baseName);
+      hostId = host.id;
+    } else if (kind === 'akamai') {
+      const host = await helpers.createTestAkamaiHost(propertyId, baseName);
+      hostId = host.id;
     }
+    const attributes = {
+      name: makeNameForTestObject('Environment', baseName),
+      stage: determineEnvironmentStage(baseName)
+    };
+    if (kind !== 'akamai') {
+      attributes.path = 'https://example.com/';
+    }
+    const response = await reactor.createEnvironment(propertyId, {
+      type: 'environments',
+      attributes: attributes,
+      relationships: {
+        host: { data: { type: 'hosts', id: hostId } }
+      }
+    });
+    expectWithContext(response.data.id, ctx).toMatch(helpers.idEN);
+    response.data.associatedHostId = hostId;
+    return response.data;
   },
 
   // Caches core extension in propertyObj.coreEx


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Respects API rate limiting for the reactor-api.
Stop swallowing errors and exit right away when there's a problem

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-14240

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Rate limits were breaking the e2e tests

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
